### PR TITLE
tests: bundle libblkio as a subproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+subprojects/libblkio/

--- a/meson.build
+++ b/meson.build
@@ -60,4 +60,12 @@ libvhost = static_library(
     c_args: libvhost_args + libvhost_optional_args + libvhost_defines,
 )
 
+libblkio_proj = subproject(
+    'libblkio',
+    default_options: [
+      'subproject-docs=disabled',
+      'subproject-examples=enabled', # used in libvhost tests
+      'subproject-tests=disabled'
+    ]
+)
 subdir('tests')

--- a/subprojects/libblkio.wrap
+++ b/subprojects/libblkio.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://gitlab.com/libblkio/libblkio.git/
+revision = fc77b38

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -16,17 +16,27 @@ vhost_user_blk_test_server = executable(
     ]
 )
 
+# If libblkio subproject doesn't define blkio_bench, this yields
+# a fatal error. It is OK as we pull a specific libblkio revision
+# which is known to define blkio_bench, and if it is missing,
+# something is certainly wrong.
+libblkio_bench_dep = libblkio_proj.get_variable('blkio_bench')
+
 envdata = environment()
 envdata.append(
     'TEST_SERVER_BINARY',
     vhost_user_blk_test_server.full_path()
+)
+envdata.append(
+    'BLKIO_BENCH_BINARY',
+    libblkio_bench_dep.full_path()
 )
 
 test(
     'unit-tests',
     import('python').find_installation('python3', modules: ['pytest']),
     args: ['-m', 'pytest', '-rsv'],
-    depends: vhost_user_blk_test_server,
+    depends: [vhost_user_blk_test_server, libblkio_bench_dep],
     env: envdata,
     workdir: meson.current_source_dir(),
     timeout: 150,

--- a/tests/test_libvhost.py
+++ b/tests/test_libvhost.py
@@ -10,8 +10,8 @@ from typing import Tuple, List, Generator
 # 1 GiB should be enough
 DISK_IMAGE_SIZE = 1024 * 1024 * 1024
 WORK_DIR = "work"
-LIBBLKIO_GIT = "https://gitlab.com/libblkio/libblkio.git/"
 TEST_SERVER_BINARY_ENV_PATH = "TEST_SERVER_BINARY"
+BLKIO_BENCH_ENV_PATH = "BLKIO_BENCH_BINARY"
 
 
 def base_dir_abs_path() -> str:
@@ -24,19 +24,18 @@ def build_dir() -> str:
 
 @pytest.fixture(scope="session")
 def blkio_bench() -> str:
-    repo_path = os.path.join(base_dir_abs_path(), "libblkio")
-    build_dir = os.path.join(repo_path, "build")
-    blkio_bench_path = os.path.join(build_dir, "examples", "blkio-bench")
+    env_path = os.environ.get(BLKIO_BENCH_ENV_PATH)
+    if env_path and os.path.exists(env_path):
+        return env_path
 
-    if not os.path.exists(repo_path):
-        subprocess.check_call(["git", "clone", LIBBLKIO_GIT, repo_path])
+    blkio_bench_path = os.path.join(
+        build_dir(), "subprojects", "libblkio", "examples", "blkio-bench"
+    )
+    if os.path.exists(blkio_bench_path):
+        return blkio_bench_path
 
-    if not os.path.exists(blkio_bench_path):
-        shutil.rmtree(build_dir, ignore_errors=True)
-        subprocess.check_call(["meson", "setup", build_dir, repo_path])
-        subprocess.check_call(["ninja"], cwd=build_dir)
-
-    return blkio_bench_path
+    raise RuntimeError("This test requires blkio-bench example program "
+                       "which comes with libblkio")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Cloning and building libblkio from within tests is suboptimal: missing dependencies are not fully caught during setup phase and test runs are longer, especially for the first time. As our README suggest running tests straight after cloning a repo, it may raise some eyebrows unnecessarily.

Bundle libblkio as a subproject instead and build only minimal subset of it required to get blkio-bench working. This results in faster, more stable test cycles for the first time as well as during development.