### PR TITLE
tests: enable and disable via an option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,12 +60,14 @@ libvhost = static_library(
     c_args: libvhost_args + libvhost_optional_args + libvhost_defines,
 )
 
-libblkio_proj = subproject(
-    'libblkio',
-    default_options: [
-      'subproject-docs=disabled',
-      'subproject-examples=enabled', # used in libvhost tests
-      'subproject-tests=disabled'
-    ]
-)
-subdir('tests')
+if not get_option('tests').disabled()
+  libblkio_proj = subproject(
+      'libblkio',
+      default_options: [
+        'subproject-docs=disabled',
+        'subproject-examples=enabled', # used in libvhost tests
+        'subproject-tests=disabled'
+      ]
+  )
+  subdir('tests')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('tests', type : 'feature', value : 'auto', description : 'Build tests and pull libblkio subproject')


### PR DESCRIPTION
Add an option named "tests" to enable or disable test suite during builds. If tests are disabled, libblkio subproject is also not built.