### PR TITLE
tests: build always but make libblkio optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,14 +60,13 @@ libvhost = static_library(
     c_args: libvhost_args + libvhost_optional_args + libvhost_defines,
 )
 
-if not get_option('tests').disabled()
-  libblkio_proj = subproject(
-      'libblkio',
-      default_options: [
-        'subproject-docs=disabled',
-        'subproject-examples=enabled', # used in libvhost tests
-        'subproject-tests=disabled'
-      ]
-  )
-  subdir('tests')
-endif
+libblkio_proj = subproject(
+    'libblkio',
+    default_options: [
+      'subproject-docs=disabled',
+      'subproject-examples=enabled', # used in libvhost tests
+      'subproject-tests=disabled'
+    ],
+    required: get_option('libblkio')
+)
+subdir('tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,1 @@
-option('tests', type : 'feature', value : 'auto', description : 'Build tests and pull libblkio subproject')
+option('libblkio', type : 'feature', value : 'auto', description : 'Pull libblkio subproject (required for tests)')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -16,6 +16,12 @@ vhost_user_blk_test_server = executable(
     ]
 )
 
+# If libblkio is disabled, we have no client to run
+# against vhost-user-blk-test-server, so nothing to do here.
+if not libblkio_proj.found()
+  subdir_done()
+endif
+
 # If libblkio subproject doesn't define blkio_bench, this yields
 # a fatal error. It is OK as we pull a specific libblkio revision
 # which is known to define blkio_bench, and if it is missing,


### PR DESCRIPTION
Disabling tests is a poor practice. Moreover, vhost-user-blk-test-server is also built together with tests, and it can be of use of its own, even if the client which comes with libblkio is unavailable.

So refine the logic from commit f616673: build tests unconditionally, but don't run them is libblkio is disabled.