### PR TITLE
subprojects: bump libblkio

### DIFF
--- a/subprojects/libblkio.wrap
+++ b/subprojects/libblkio.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://gitlab.com/libblkio/libblkio.git/
-revision = 6635473
+revision = af00020


### PR DESCRIPTION
This fixes compile errors on rust 1.85 used by ubuntu-latest.