### PR TITLE
catomic.h: allow complilation on arm64

### DIFF
--- a/catomic.h
+++ b/catomic.h
@@ -24,7 +24,7 @@
  * slow this down unnecessarily. This seems not to be the case on x86_64; need
  * to recheck if we ever build for another arch.
  */
-#ifndef __x86_64__
+#if !defined(__x86_64__) && !defined(__aarch64__)
 #error Verify smp_read_barrier_depends incurs no extra costs
 #endif
 #define smp_read_barrier_depends()      \
@@ -45,7 +45,7 @@
  * catomic_rcu_read potentially has the same issue with consume order as
  * smp_read_barrier_depends, see above.
  */
-#ifndef __x86_64__
+#if !defined(__x86_64__) && !defined(__aarch64__)
 #error Verify catomic_rcu_read incurs no extra costs
 #endif
 #define catomic_rcu_read(ptr)      __atomic_load_n(ptr, __ATOMIC_CONSUME)


### PR DESCRIPTION
We conducted internal testing of this library
on ARM64 hosts by running a QEMU virtual machine
with a vhost-based boot disk.

The guest booted successfully, and the fio
performance appears good and is comparable
to x86 on a per-queue basis when using a ramfs
backend with fio parameters direct=1 and iodepth=64.

randwrite 4k:
	x86_64 IOPS=49.5k, BW=193MiB/s
	arm64 IOPS=48.0k, BW=188MiB/s

randread 4k:
	x86 IOPS=195k, BW=761MiB/s
	arm64 IOPS=258k, BW=1009MiB/s

read_seq 128k:
	x86: IOPS=36.7k, BW=4588MiB/s
	arm64: IOPS=80.1k, BW=9.78GiB/s

write_seq 128k:
	x86: IOPS=9562, BW=1195MiB/s
	arm64: IOPS=16.7k, BW=2089MiB/s