### PR TITLE
Host (runtime) page size support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(vhost-server PRIVATE
   memmap.c
   server.c
   vdev.c
+  platform.c
   virtio/virt_queue.c
   virtio/virtio_blk.c
   virtio/virtio_fs.c

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ libvhost_sources = files([
     'memmap.c',
     'server.c',
     'vdev.c',
+    'platform.c',
     'virtio/virtio_blk.c',
     'virtio/virtio_fs.c',
     'virtio/virt_queue.c'

--- a/platform.c
+++ b/platform.c
@@ -1,0 +1,17 @@
+#include <errno.h>
+#include <unistd.h>
+
+#include "platform.h"
+
+int init_platform_page_size(void)
+{
+    if (!platform_page_size) {
+        long result = sysconf(_SC_PAGESIZE);
+        if (result < 0) {
+            return errno;
+        }
+        platform_page_size = result;
+    }
+
+    return 0;
+}

--- a/platform.h
+++ b/platform.h
@@ -11,9 +11,6 @@
 #include <unistd.h>
 #include <stdarg.h>
 
-#define PAGE_SHIFT  12
-#define PAGE_SIZE   (1ul << PAGE_SHIFT)
-
 #define HUGE_PAGE_SIZE 0x200000
 
 /*////////////////////////////////////////////////////////////////////////////*/
@@ -216,3 +213,7 @@ static inline char *vhd_strdup_printf(const char *fmt, ...)
     }
     return ret;
 }
+
+int init_platform_page_size(void);
+
+extern size_t platform_page_size;

--- a/server.c
+++ b/server.c
@@ -35,6 +35,14 @@ static void *vhost_evloop_func(void *arg)
 
 int vhd_start_vhost_server(log_function log_fn)
 {
+    int res;
+
+    res = init_platform_page_size();
+    if (res != 0) {
+        VHD_LOG_ERROR("failed to init platform page size: %d", res);
+        return -res;
+    }
+
     if (g_vhost_evloop != NULL) {
         return 0;
     }
@@ -47,7 +55,7 @@ int vhd_start_vhost_server(log_function log_fn)
         return -EIO;
     }
 
-    int res = pthread_create(&g_vhost_thread, NULL, vhost_evloop_func, NULL);
+    res = pthread_create(&g_vhost_thread, NULL, vhost_evloop_func, NULL);
     if (res != 0) {
         VHD_LOG_ERROR("failed to start vhost event loop thread: %d", res);
         free_vhost_event_loop();

--- a/virtio/virtio_spec.h
+++ b/virtio/virtio_spec.h
@@ -15,8 +15,6 @@ extern "C" {
 #endif
 
 #define VIRTQ_SIZE_MAX  32768u
-#define VIRTQ_ALIGNMENT PAGE_SIZE
-#define VIRTQ_ALIGN(x)  (((x) + VIRTQ_ALIGNMENT) & ~VIRTQ_ALIGNMENT)
 
 struct virtq_desc {
     /* Address (guest-physical). */
@@ -87,11 +85,16 @@ VHD_STATIC_ASSERT(sizeof(struct virtq_used) == 4);
  * };
 */
 
+static inline size_t virtq_align(size_t size)
+{
+    return (size + platform_page_size) & ~platform_page_size;
+}
+
 static inline unsigned virtq_size(unsigned int qsz)
 {
-    return VIRTQ_ALIGN(sizeof(struct virtq_desc) * qsz +
+    return virtq_align(sizeof(struct virtq_desc) * qsz +
                        sizeof(le16) * (3 + qsz))
-         + VIRTQ_ALIGN(sizeof(le16) * 3 +
+         + virtq_align(sizeof(le16) * 3 +
                        sizeof(struct virtq_used_elem) * qsz);
 }
 


### PR DESCRIPTION
Added dynamic (runtime) support for host page sizes, allowing a single library binary to run on hosts with either 4K or 64K pages.