### PR TITLE
Introduce configurable periodic PTE flushing

### DIFF
--- a/blockdev.c
+++ b/blockdev.c
@@ -145,7 +145,8 @@ struct vhd_vdev *vhd_register_blockdev(const struct vhd_bdev_info *bdev,
     res = vhd_vdev_init_server(&dev->vdev, bdev->socket_path,
                                &g_virtio_blk_vdev_type,
                                bdev->num_queues, rqs, num_rqs, priv,
-                               bdev->map_cb, bdev->unmap_cb);
+                               bdev->map_cb, bdev->unmap_cb,
+                               bdev->pte_flush_byte_threshold);
     if (res != 0) {
         goto error_out;
     }

--- a/fs.c
+++ b/fs.c
@@ -91,7 +91,7 @@ struct vhd_vdev *vhd_register_fs(struct vhd_fsdev_info *fsdev,
     }
 
     res = vhd_vdev_init_server(&dev->vdev, fsdev->socket_path, &g_virtio_fs_vdev_type,
-                               fsdev->num_queues, &rq, 1, priv, NULL, NULL);
+                               fsdev->num_queues, &rq, 1, priv, NULL, NULL, 0);
     if (res != 0) {
         goto error_out;
     }

--- a/include/vhost/blockdev.h
+++ b/include/vhost/blockdev.h
@@ -46,6 +46,14 @@ struct vhd_bdev_info {
 
     /* Gets called before unmapping guest memory region */
     int (*unmap_cb)(void *addr, size_t len);
+
+    /*
+     * If set to a non-zero value, PTEs backing the guest memory regions
+     * for this blockdev are flushed (unmapped and mapped back) every
+     * N bytes processed by the backend. E.g. if this value is 1024, PTEs
+     * will be flushed after the guest reads/writes 2 blocks.
+     */
+    size_t pte_flush_byte_threshold;
 };
 
 static inline bool vhd_blockdev_is_readonly(const struct vhd_bdev_info *bdev)

--- a/memmap.h
+++ b/memmap.h
@@ -14,6 +14,7 @@ struct vhd_memory_map;
 struct vhd_memory_map *vhd_memmap_new(int (*map_cb)(void *, size_t),
                                       int (*unmap_cb)(void *, size_t));
 struct vhd_memory_map *vhd_memmap_dup(struct vhd_memory_map *mm);
+struct vhd_memory_map *vhd_memmap_dup_remap(struct vhd_memory_map *mm);
 
 size_t vhd_memmap_max_memslots(void);
 

--- a/memmap.h
+++ b/memmap.h
@@ -2,6 +2,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <sys/mman.h>
 
 #ifdef __cplusplus
@@ -17,7 +18,7 @@ struct vhd_memory_map *vhd_memmap_dup(struct vhd_memory_map *mm);
 size_t vhd_memmap_max_memslots(void);
 
 int vhd_memmap_add_slot(struct vhd_memory_map *mm, uint64_t gpa, uint64_t uva,
-                        size_t size, int fd, off_t offset);
+                        size_t size, int fd, off_t offset, bool preserve_fd);
 int vhd_memmap_del_slot(struct vhd_memory_map *mm, uint64_t gpa, uint64_t uva,
                         size_t size);
 

--- a/platform.h
+++ b/platform.h
@@ -54,6 +54,8 @@ extern "C" {
 #   define VHD_TYPEOF               __typeof
 #   define VHD_PACKED               __attribute__((packed))
 
+#define VHD_ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 /* Return 0-based index of first least significant bit set in 32-bit value */
 static inline int vhd_find_first_bit32(uint32_t val)
 {

--- a/tests/test_libvhost.py
+++ b/tests/test_libvhost.py
@@ -75,8 +75,7 @@ def disk_image(work_dir: str) -> Generator[str, None, None]:
     os.remove(disk_image_path)
 
 
-@pytest.fixture(scope="class")
-def server_socket(
+def create_server(
     work_dir: str, disk_image: str, vhost_user_test_server: str
 ) -> Generator[str, None, None]:
     socket_path = os.path.join(work_dir, "server.sock")
@@ -104,6 +103,13 @@ def server_socket(
 
     process.send_signal(signal.SIGINT)
     process.wait(10)
+
+
+@pytest.fixture(scope="class")
+def server_socket(
+    work_dir: str, disk_image: str, vhost_user_test_server: str
+) -> Generator[str, None, None]:
+    yield from create_server(work_dir, disk_image, vhost_user_test_server)
 
 
 def pretty_print_blkio_config(param: List[str]) -> str:

--- a/tests/test_libvhost.py
+++ b/tests/test_libvhost.py
@@ -75,7 +75,7 @@ def disk_image(work_dir: str) -> Generator[str, None, None]:
     os.remove(disk_image_path)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="class")
 def server_socket(
     work_dir: str, disk_image: str, vhost_user_test_server: str
 ) -> Generator[str, None, None]:
@@ -121,17 +121,18 @@ def check_run_blkio_bench(
     ], timeout=time + 10)
 
 
-@pytest.mark.parametrize(
-    'config',
-    [
-        ["read", 1024 * 1024],
-        ["write", 1024 * 1024],
-        ["randread", 4096],
-        ["randwrite", 4096],
-    ],
-    ids=pretty_print_blkio_config
-)
-def test_basic_operations(
-    server_socket: str, blkio_bench: str, config: Tuple[str, int]
-) -> None:
-    check_run_blkio_bench(blkio_bench, *config, 30, server_socket)
+class TestBasic:
+    @pytest.mark.parametrize(
+        'config',
+        [
+            ["read", 1024 * 1024],
+            ["write", 1024 * 1024],
+            ["randread", 4096],
+            ["randwrite", 4096],
+        ],
+        ids=pretty_print_blkio_config
+    )
+    def test_basic_operations(
+        self, server_socket: str, blkio_bench: str, config: Tuple[str, int]
+    ) -> None:
+        check_run_blkio_bench(blkio_bench, *config, 30, server_socket)

--- a/tests/vhost_user_blk_test_server.c
+++ b/tests/vhost_user_blk_test_server.c
@@ -61,6 +61,7 @@ struct disk_config {
     bool support_discard;
     bool support_write_zeroes;
     unsigned long batch_size;
+    unsigned long pte_flush_threshold;
     unsigned long num_rqs;
 };
 
@@ -441,6 +442,7 @@ static int init_disk(struct disk *d)
     d->info.total_blocks = file_len / VHD_SECTOR_SIZE;
     d->info.map_cb = NULL;
     d->info.unmap_cb = NULL;
+    d->info.pte_flush_byte_threshold = conf->pte_flush_threshold;
 
     if (conf->readonly) {
         d->info.features |= VHD_BDEV_F_READONLY;
@@ -480,6 +482,8 @@ static void usage(const char *cmd)
     printf("      ,num-rqs=NUM       NUM of rqs to spawn\n");
     printf("      ,batch-size=NUM    submit/complete i/o in batches "
            "of up to NUM\n");
+    printf("      ,pte-flush-threshold=NUM Bytes to process before flushing "
+           "the PTEs (0 disables this)\n");
     printf("  -m, --monitor=PATH      Unix socket for interactive command line "
            "to operate with sever. Or 'stdio' keyword to operate through stdin "
            "and stdout\n");
@@ -535,6 +539,7 @@ enum disk_arg {
     DISK_ARG_DELAY,
     DISK_ARG_NUM_RQS,
     DISK_ARG_BATCH_SIZE,
+    DISK_ARG_PTE_FLUSH_THRESHOLD,
 };
 
 static char *const disk_arg_tokens[] = {
@@ -547,6 +552,7 @@ static char *const disk_arg_tokens[] = {
     [DISK_ARG_DELAY] = "delay",
     [DISK_ARG_NUM_RQS] = "num-rqs",
     [DISK_ARG_BATCH_SIZE] = "batch-size",
+    [DISK_ARG_PTE_FLUSH_THRESHOLD] = "pte-flush-threshold",
     NULL
 };
 
@@ -572,6 +578,7 @@ static struct arg_setter disk_arg_setters[] = {
     [DISK_ARG_DELAY] = { set_ul, CONF_FIELD(delay) },
     [DISK_ARG_NUM_RQS] = { set_ul, CONF_FIELD(num_rqs) },
     [DISK_ARG_BATCH_SIZE] = { set_ul, CONF_FIELD(batch_size) },
+    [DISK_ARG_PTE_FLUSH_THRESHOLD] = { set_ul, CONF_FIELD(pte_flush_threshold) },
 };
 
 static bool parse_disk_args(const char *args, struct disk_config *conf)

--- a/vdev.c
+++ b/vdev.c
@@ -60,8 +60,7 @@ static const char *const vhost_req_names[] = {
 
 static const char *vhost_req_name(uint32_t req)
 {
-    if (req >= sizeof(vhost_req_names) / sizeof(vhost_req_names[0]) ||
-        !vhost_req_names[req]) {
+    if (req >= VHD_ARRAY_SIZE(vhost_req_names) || !vhost_req_names[req]) {
         return "**UNKNOWN**";
     }
     return vhost_req_names[req];

--- a/vdev.c
+++ b/vdev.c
@@ -893,7 +893,8 @@ static int vhost_set_mem_table(struct vhd_vdev *vdev, const void *payload,
     for (i = 0; i < desc->nregions; i++) {
         const struct vhost_user_mem_region *region = &desc->regions[i];
         ret = vhd_memmap_add_slot(mm, region->guest_addr, region->user_addr,
-                                  region->size, fds[i], region->mmap_offset);
+                                  region->size, fds[i], region->mmap_offset,
+                                  false);
         if (ret < 0) {
             goto fail;
         }
@@ -964,7 +965,8 @@ static int vhost_add_mem_reg(struct vhd_vdev *vdev, const void *payload,
     }
 
     ret = vhd_memmap_add_slot(mm, region->guest_addr, region->user_addr,
-                              region->size, fds[0], region->mmap_offset);
+                              region->size, fds[0], region->mmap_offset,
+                              false);
     if (ret < 0) {
         goto fail;
     }

--- a/vdev.h
+++ b/vdev.h
@@ -100,6 +100,9 @@ struct vhd_vdev {
     struct inflight_split_region *inflight_mem;
     uint64_t inflight_size;
 
+    size_t pte_flush_byte_threshold;
+    int64_t bytes_left_before_pte_flush;
+
     /* #vrings which may have requests in flight */
     uint16_t num_vrings_in_flight;
     /* #vrings started and haven't yet acknowledged stop */
@@ -119,6 +122,7 @@ struct vhd_vdev {
 
     /* whether an ACK should be sent once the message is handled  */
     bool ack_pending;
+    bool pte_flush_pending;
 
     /* fd to keep open until handle_complete and to close there */
     int keep_fd;
@@ -137,6 +141,9 @@ struct vhd_vdev {
  * @priv            User private data
  * @map_cb          User function to call after mapping guest memory
  * @unmap_cb        User function to call before unmapping guest memory
+ * @pte_flush_byte_threshold
+ *                  Number of bytes to process before flushing the PTEs
+ *                  of the guest address space
  */
 int vhd_vdev_init_server(
     struct vhd_vdev *vdev,
@@ -146,7 +153,8 @@ int vhd_vdev_init_server(
     struct vhd_request_queue **rqs, int num_rqs,
     void *priv,
     int (*map_cb)(void *addr, size_t len),
-    int (*unmap_cb)(void *addr, size_t len));
+    int (*unmap_cb)(void *addr, size_t len),
+    size_t pte_flush_byte_threshold);
 
 /**
  * Stop vhost device.  Once this returns no more new requests will reach the


### PR DESCRIPTION
128GiB VM, fio scenario to read 100GiB from disk:
- before: `VmPTE: 169164 kB`
- after (flush every 1GiB): `VmPTE: 688 kB`

No IOPS penalty detected