### PR TITLE
subprojects/libblkio: bump version

### DIFF
--- a/subprojects/libblkio.wrap
+++ b/subprojects/libblkio.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://gitlab.com/libblkio/libblkio.git/
-revision = aef5166a
+revision = 9358fd69


### PR DESCRIPTION
This fixes GHA with rustc 1.88.0