### PR TITLE
Interrupt coalescing

### DIFF
--- a/blockdev.c
+++ b/blockdev.c
@@ -174,6 +174,11 @@ struct vhd_vdev *vhd_register_blockdev(const struct vhd_bdev_info *bdev,
         goto error_out;
     }
 
+    if (bdev->notify_coalesce_period_ns) {
+        dev->vdev.notify_coalesce_period_ticks =
+            vhd_ns_to_ticks(bdev->notify_coalesce_period_ns);
+    }
+
     LIST_INSERT_HEAD(&g_bdev_list, dev, blockdevs);
     return &dev->vdev;
 

--- a/fs.c
+++ b/fs.c
@@ -104,6 +104,11 @@ struct vhd_vdev *vhd_register_fs_mq(struct vhd_fsdev_info *fsdev,
         goto error_out;
     }
 
+    if (fsdev->notify_coalesce_period_ns) {
+        dev->vdev.notify_coalesce_period_ticks =
+            vhd_ns_to_ticks(fsdev->notify_coalesce_period_ns);
+    }
+
     LIST_INSERT_HEAD(&g_fsdev_list, dev, fsdevs);
     return &dev->vdev;
 

--- a/include/vhost/blockdev.h
+++ b/include/vhost/blockdev.h
@@ -75,6 +75,16 @@ struct vhd_bdev_info {
      * will be flushed after the guest reads/writes 2 blocks.
      */
     size_t pte_flush_byte_threshold;
+
+    /*
+     * If set to a non-zero value, used ring notifications to the guest
+     * are coalesced: a notification is sent only if at least this many
+     * nanoseconds have elapsed since the last one, or if the virtio
+     * protocol mandates it (EVENT_IDX / flags-based suppression still
+     * applies).  Zero (default) means every eligible completion triggers
+     * an immediate notification.
+     */
+    uint64_t notify_coalesce_period_ns;
 };
 
 static inline bool vhd_blockdev_is_readonly(const struct vhd_bdev_info *bdev)

--- a/include/vhost/fs.h
+++ b/include/vhost/fs.h
@@ -22,6 +22,15 @@ struct vhd_fsdev_info {
 
     /* Total number of backend queues this device supports */
     uint32_t num_queues;
+
+    /*
+     * If set to a non-zero value, used ring notifications to the guest
+     * are coalesced: a notification is sent only if at least this many
+     * nanoseconds have elapsed since the last one, or if the virtio
+     * protocol mandates it.  Zero (default) means every eligible
+     * completion triggers an immediate notification.
+     */
+    uint64_t notify_coalesce_period_ns;
 };
 
 /**

--- a/platform.c
+++ b/platform.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "platform.h"
@@ -15,3 +16,57 @@ int init_platform_page_size(void)
 
     return 0;
 }
+
+/*
+ * Tick counter frequency, set once by init_ticks_freq().
+ */
+static uint64_t ticks_per_sec;
+
+int init_ticks_freq(void)
+{
+    if (ticks_per_sec) {
+        return 0;
+    }
+
+#if defined(__aarch64__)
+    {
+        uint64_t freq;
+        __asm__ __volatile__("mrs %0, cntfrq_el0" : "=r"(freq));
+        ticks_per_sec = freq;
+    }
+#elif defined(__x86_64__)
+    {
+        /*
+         * Calibrate TSC against CLOCK_MONOTONIC.  A 10 ms window gives
+         * sub-percent accuracy which is plenty for coalescing periods.
+         */
+        struct timespec ts1, ts2;
+        uint64_t t1, t2;
+        uint64_t ns;
+
+        clock_gettime(CLOCK_MONOTONIC, &ts1);
+        t1 = vhd_ticks();
+
+        /* Busy-spin for ~10 ms */
+        do {
+            clock_gettime(CLOCK_MONOTONIC, &ts2);
+            ns = (uint64_t)(ts2.tv_sec - ts1.tv_sec) * 1000000000ULL
+                 + (uint64_t)(ts2.tv_nsec - ts1.tv_nsec);
+        } while (ns < 10000000ULL);
+
+        t2 = vhd_ticks();
+        ticks_per_sec = (t2 - t1) * 1000000000ULL / ns;
+    }
+#else
+#   error Unsupported architecture for init_ticks_freq
+#endif
+
+    return ticks_per_sec ? 0 : -ENODEV;
+}
+
+uint64_t vhd_ns_to_ticks(uint64_t ns)
+{
+    VHD_ASSERT(ticks_per_sec);
+    return ns * ticks_per_sec / 1000000000ULL;
+}
+

--- a/platform.h
+++ b/platform.h
@@ -23,6 +23,28 @@ extern "C" {
 
 #define HUGE_PAGE_SIZE 0x40000000 // 1G, works also for 2M pages alignment
 
+/*
+ * Fast monotonic tick counter — single inline instruction, no syscall.
+ * Use vhd_ns_to_ticks() to convert nanoseconds to tick units.
+ */
+static inline uint64_t vhd_ticks(void)
+{
+#if defined(__x86_64__)
+    uint32_t lo, hi;
+    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+    return ((uint64_t)hi << 32) | lo;
+#elif defined(__aarch64__)
+    uint64_t val;
+    __asm__ __volatile__("mrs %0, cntvct_el0" : "=r"(val));
+    return val;
+#else
+#   error Unsupported architecture for vhd_ticks
+#endif
+}
+
+int init_ticks_freq(void);
+uint64_t vhd_ns_to_ticks(uint64_t ns);
+
 /*////////////////////////////////////////////////////////////////////////////*/
 
 #if !defined(NDEBUG)

--- a/server.c
+++ b/server.c
@@ -52,6 +52,12 @@ int vhd_start_vhost_server(log_function log_fn)
         return -res;
     }
 
+    res = init_ticks_freq();
+    if (res != 0) {
+        VHD_LOG_ERROR("failed to calibrate tick frequency: %d", res);
+        return -res;
+    }
+
     if (g_vhost_evloop != NULL) {
         return 0;
     }
@@ -121,6 +127,11 @@ struct vhd_request_queue {
 
     struct vhd_bh *completion_bh;
     struct vhd_rq_metrics metrics;
+
+    /* Periodic poll for flushing coalesced notifications */
+    void (*notify_poll_cb)(void *);
+    void *notify_poll_opaque;
+    bool notify_poll_active;
 };
 
 void vhd_run_in_rq(struct vhd_request_queue *rq, void (*cb)(void *),
@@ -209,7 +220,25 @@ struct vhd_io_handler *vhd_add_rq_io_handler(struct vhd_request_queue *rq,
 
 int vhd_run_queue(struct vhd_request_queue *rq)
 {
-    return vhd_run_event_loop(rq->evloop, -1);
+    bool has_inflight = rq->notify_poll_active &&
+                        (!TAILQ_EMPTY(&rq->inflight) ||
+                         !TAILQ_EMPTY(&rq->submission));
+    int timeout = has_inflight ? 0 : -1;
+    int res = vhd_run_event_loop(rq->evloop, timeout);
+
+    if (rq->notify_poll_cb) {
+        rq->notify_poll_cb(rq->notify_poll_opaque);
+    }
+
+    return res;
+}
+
+void vhd_rq_set_notify_poll(struct vhd_request_queue *rq,
+                             void (*cb)(void *), void *opaque)
+{
+    rq->notify_poll_cb = cb;
+    rq->notify_poll_opaque = opaque;
+    rq->notify_poll_active = true;
 }
 
 void vhd_stop_queue(struct vhd_request_queue *rq)

--- a/server_internal.h
+++ b/server_internal.h
@@ -46,3 +46,12 @@ int vhd_submit_ctl_work_and_wait(void (*func)(struct vhd_work *, void *),
                                  void *opaque);
 
 bool vhd_in_ctl_thread(void);
+
+/*
+ * Register a poll callback for flushing coalesced notifications.
+ * The callback runs after each event loop iteration.  When active,
+ * epoll_wait uses timeout 0 (non-blocking) so pending notifications
+ * are flushed promptly.
+ */
+void vhd_rq_set_notify_poll(struct vhd_request_queue *rq,
+                             void (*cb)(void *), void *opaque);

--- a/vdev.c
+++ b/vdev.c
@@ -175,6 +175,8 @@ static int vring_update_shadow_vq_addrs(struct vhd_vring *vring,
     return 0;
 }
 
+static void vring_disarm_notify_timer(struct vhd_vring *vring);
+
 static void vring_sync_to_virtq(struct vhd_vring *vring)
 {
     bool should_kick;
@@ -196,6 +198,7 @@ static void vring_sync_to_virtq(struct vhd_vring *vring)
     vring->vq.enabled = vring->shadow_vq.enabled;
 
     virtq_set_notify_fd(&vring->vq, vring->callfd);
+    vring_disarm_notify_timer(vring);
 
     if (should_kick) {
         vhd_set_eventfd(vring->kickfd);
@@ -382,6 +385,78 @@ void vhd_vring_dec_in_flight(struct vhd_vring *vring)
     }
 }
 
+/*
+ * Notification coalescing: rate-limits used ring notifications to the guest.
+ * No syscalls on the hot path -- uses rdtsc / cntvct_el0 (single inline
+ * instruction) and a simple pending flag.  Pending notifications are flushed
+ * either when the coalescing period elapses on a subsequent completion, or
+ * when the guest kicks (virtq_dequeue_many).
+ */
+
+static void vring_coalesce_notify_cb(struct virtio_virtq *vq,
+                                     bool need_notify)
+{
+    struct vhd_vring *vring = VHD_VRING_FROM_VQ(vq);
+
+    if (need_notify) {
+        vring->notify_pending = true;
+    }
+
+    if (!vring->notify_pending) {
+        return;
+    }
+
+    uint64_t now = vhd_ticks();
+
+    if (now - vring->last_notify_ticks
+            >= vring->vdev->notify_coalesce_period_ticks) {
+        vring->last_notify_ticks = now;
+        vring->notify_pending = false;
+        virtq_do_notify(vq);
+    }
+}
+
+static void vring_disarm_notify_timer(struct vhd_vring *vring)
+{
+    vring->notify_pending = false;
+}
+
+/*
+ * Poll callback registered on the request queue.  Called after each
+ * event loop iteration (including epoll_wait timeout) to:
+ * 1. Dispatch new requests (since kicks are suppressed per virtio 2.7.10)
+ * 2. Flush any pending coalesced notifications whose period has elapsed.
+ */
+static void rq_notify_poll(void *opaque)
+{
+    struct vhd_request_queue *rq = opaque;
+    struct vhd_vdev *vdev;
+
+    LIST_FOREACH(vdev, &g_vdevs, vdev_list) {
+        if (!vdev->notify_coalesce_period_ticks) {
+            continue;
+        }
+        for (uint16_t i = 0; i < vdev->num_queues; i++) {
+            struct vhd_vring *vring = &vdev->vrings[i];
+
+            if (!vring->started_in_rq ||
+                vhd_get_rq_for_vring(vring) != rq) {
+                continue;
+            }
+
+            /* Poll avail ring directly since kicks are suppressed */
+            if (vring->vq.enabled) {
+                vdev->type->dispatch_requests(vdev, vring);
+            }
+
+            /* Flush any pending coalesced notification */
+            if (vring->notify_pending) {
+                vring_coalesce_notify_cb(&vring->vq, false);
+            }
+        }
+    }
+}
+
 static void vring_stop_bh(void *opaque)
 {
     struct vhd_vring *vring = opaque;
@@ -389,6 +464,12 @@ static void vring_stop_bh(void *opaque)
     if (!vring->started_in_rq) {
         return;
     }
+
+    if (vring->vq.polling) {
+        virtq_enable_kicks(&vring->vq);
+    }
+    vring->vq.notify_cb = NULL;
+    vring->notify_pending = false;
 
     vhd_del_io_handler(vring->kick_handler);
     vring->kick_handler = NULL;
@@ -1409,6 +1490,15 @@ static void vring_start_bh(void *opaque)
     if (!vring->kick_handler) {
         VHD_OBJ_ERROR(vring, "Could not attach kick handler");
         goto fail;
+    }
+
+    if (vring->vdev->notify_coalesce_period_ticks) {
+        struct vhd_request_queue *rq = vhd_get_rq_for_vring(vring);
+
+        vring->last_notify_ticks = vhd_ticks();
+        vring->vq.notify_cb = vring_coalesce_notify_cb;
+        vring->vq.polling = true;
+        vhd_rq_set_notify_poll(rq, rq_notify_poll, rq);
     }
 
     vring_sync_to_virtq(vring);

--- a/vdev.h
+++ b/vdev.h
@@ -103,6 +103,9 @@ struct vhd_vdev {
     size_t pte_flush_byte_threshold;
     int64_t bytes_left_before_pte_flush;
 
+    /* Notification coalescing period for all vrings */
+    uint64_t notify_coalesce_period_ticks;
+
     /* #vrings which may have requests in flight */
     uint16_t num_vrings_in_flight;
     /* #vrings started and haven't yet acknowledged stop */
@@ -203,6 +206,10 @@ struct vhd_vring {
         struct vhd_memory_log *log;
         bool enabled;
     } shadow_vq;
+
+    /* Notification coalescing state (no syscalls, single-threaded) */
+    uint64_t last_notify_ticks;
+    bool notify_pending;
 
     /*
      * the fields below are only accessed in dataplane unless the vring is

--- a/virtio/virt_queue.c
+++ b/virtio/virt_queue.c
@@ -462,6 +462,11 @@ int virtq_dequeue_many(struct virtio_virtq *vq,
     uint16_t avail, avail2;
     time_t now;
 
+    /* Flush any pending coalesced notification on the kick path */
+    if (vq->notify_cb) {
+        vq->notify_cb(vq, false);
+    }
+
     if (virtq_is_broken(vq)) {
         VHD_OBJ_ERROR(vq, "virtqueue is broken, cannot process");
         return -ENODEV;
@@ -486,8 +491,21 @@ int virtq_dequeue_many(struct virtio_virtq *vq,
 
     vq->stat.metrics.dispatch_total++;
 
+    /*
+     * Virtio spec 2.7.10: suppress driver notifications while we're
+     * actively polling the avail ring, so the guest doesn't waste
+     * cycles on kick eventfd writes.
+     */
+    if (vq->polling) {
+        if (!vq->has_event_idx) {
+            vq->used->flags |= VIRTQ_USED_F_NO_NOTIFY;
+            smp_mb(); /* flags write before avail->idx read */
+        }
+        /* EVENT_IDX: just skip the avail_event update below */
+    }
+
     avail = vq->avail->idx;
-    if (vq->has_event_idx) {
+    if (vq->has_event_idx && !vq->polling) {
         smp_mb(); /* avail->idx read followed by avail_event write */
         while (true) {
             virtq_set_avail_event(vq, avail);
@@ -521,8 +539,6 @@ int virtq_dequeue_many(struct virtio_virtq *vq,
     /* Make sure that further desc reads do not pass avail->idx read. */
     smp_rmb();                  /* barrier pair [A] */
 
-    /* TODO: disable extra notifies from this point */
-
     for (i = 0; i < num_avail; ++i) {
         /* Grab next descriptor head */
         uint16_t head = vq->avail->ring[vq->last_avail % vq->qsz];
@@ -540,7 +556,6 @@ int virtq_dequeue_many(struct virtio_virtq *vq,
         vq->stat.metrics.request_total++;
     }
 
-    /* TODO: restore notifier mask here */
     return 0;
 
 queue_broken:
@@ -614,7 +629,7 @@ static void vhd_log_modified(struct virtio_virtq *vq,
     }
 }
 
-static void virtq_do_notify(struct virtio_virtq *vq)
+void virtq_do_notify(struct virtio_virtq *vq)
 {
     if (vq->notify_fd != -1) {
         eventfd_write(vq->notify_fd, 1);
@@ -652,7 +667,14 @@ static void virtq_notify(struct virtio_virtq *vq)
     /* expose used ring entries before checking used event */
     smp_mb();
 
-    if (virtq_need_notify(vq)) {
+    if (vq->notify_cb) {
+        /*
+         * Coalescing path: let the callback decide whether and when to
+         * notify.  Pass the virtio-spec need_notify result so the
+         * callback can track pending notifications.
+         */
+        vq->notify_cb(vq, virtq_need_notify(vq));
+    } else if (virtq_need_notify(vq)) {
         virtq_do_notify(vq);
     }
 }
@@ -696,6 +718,36 @@ void virtq_set_notify_fd(struct virtio_virtq *vq, int fd)
      * had a chance to signal guest.
      */
     virtq_do_notify(vq);
+}
+
+void virtq_enable_kicks(struct virtio_virtq *vq)
+{
+    vq->polling = false;
+
+    if (!vq->has_event_idx) {
+        vq->used->flags &= ~VIRTQ_USED_F_NO_NOTIFY;
+        smp_mb();
+    }
+
+    /*
+     * Re-enable avail_event so the driver notifies on the next submission.
+     * Use the same loop as virtq_dequeue_many to avoid missing a request
+     * that arrived while notifications were suppressed.
+     */
+    if (vq->has_event_idx) {
+        uint16_t avail = vq->avail->idx;
+        smp_mb();
+        while (true) {
+            virtq_set_avail_event(vq, avail);
+            smp_mb();
+            uint16_t avail2 = vq->avail->idx;
+            if (avail2 == avail) {
+                break;
+            }
+            smp_mb();
+            avail = avail2;
+        }
+    }
 }
 
 void virtio_virtq_get_stat(struct virtio_virtq *vq,

--- a/virtio/virt_queue.h
+++ b/virtio/virt_queue.h
@@ -74,10 +74,26 @@ struct virtio_virtq {
     int notify_fd;
 
     /*
+     * Optional callback to intercept notifications.  When set,
+     * virtq_notify() calls this on every completion instead of the default
+     * need_notify+do_notify path.  @need_notify is the result of the
+     * virtio-spec notification check.
+     * Used by the vring layer to implement notification coalescing.
+     */
+    void (*notify_cb)(struct virtio_virtq *vq, bool need_notify);
+
+    /*
      * Whether the processing of this virtq is enabled.
      * Can be toggled after virtq is started.
      */
     bool enabled;
+
+    /*
+     * When set, suppress driver notifications (kicks) per virtio spec
+     * 2.7.10.  The device polls the avail ring directly instead of
+     * relying on kick events.
+     */
+    bool polling;
 
     /* inflight information */
     uint64_t req_cnt;
@@ -120,6 +136,10 @@ int virtq_dequeue_many(struct virtio_virtq *vq,
 void virtq_push(struct virtio_virtq *vq, struct virtio_iov *iov, uint32_t len);
 
 void virtq_set_notify_fd(struct virtio_virtq *vq, int fd);
+
+void virtq_do_notify(struct virtio_virtq *vq);
+
+void virtq_enable_kicks(struct virtio_virtq *vq);
 
 void virtio_free_iov(struct virtio_iov *iov);
 uint16_t virtio_iov_get_head(struct virtio_iov *iov);


### PR DESCRIPTION
Implements interrupt coalescing with configurable interval to relieve syscall churn on libvhost and QEMU/KVM side while trading off some latency.

By default coalescing interval is not set (0), effectively restoring existing behavior.

With virtiofs shortcut (immediate response in `do_read` / `do_write`), 1 `vhd_run_queue` thread - 250k IOPS (aarch64)

<img width="3075" height="1620" alt="image" src="https://github.com/user-attachments/assets/974f0079-7517-4e43-9137-6814cb3d2a45" />

Same with 10 us coalescing - 316k IOPS

<img width="3075" height="1620" alt="image" src="https://github.com/user-attachments/assets/e72bca54-3e4b-4360-8157-b1dc32f09c43" />
