### PR TITLE
memmap.c: suppress gcc warning

### DIFF
--- a/memmap.c
+++ b/memmap.c
@@ -411,7 +411,8 @@ struct vhd_memory_map *vhd_memmap_new(int (*map_cb)(void *, size_t),
         .callbacks = (struct vhd_mmap_callbacks) {
             .map_cb = map_cb,
             .unmap_cb = unmap_cb,
-        }
+        },
+        .num = 0  /* suppress gcc warning missing-field-initializers */
     };
 
     objref_init(&mm->ref, memmap_release);


### PR DESCRIPTION
Older gcc says:

  ../subprojects/yc-libvhost-server/memmap.c:415:5: error: missing
      initializer for field 'num' of 'struct vhd_memory_map'
      [-Werror=missing-field-initializers]
    415 |     };
        |     ^
  ../subprojects/yc-libvhost-server/memmap.c:101:14: note: 'num'
      declared here
    101 |     unsigned num;
        |              ^~~

version:

    gcc --version
    gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0

Let's just satisfy it.