### PR TITLE
tests: unlink stale vhost socket before server start

### DIFF
--- a/tests/test_libvhost.py
+++ b/tests/test_libvhost.py
@@ -82,6 +82,11 @@ def create_server(
 ) -> Generator[str, None, None]:
     socket_path = os.path.join(work_dir, "server.sock")
 
+    try:
+        os.unlink(socket_path)
+    except FileNotFoundError:
+        pass
+
     process = subprocess.Popen([
         vhost_user_test_server, "--disk",
         f"socket-path={socket_path},blk-file={disk_image}"


### PR DESCRIPTION
Test server instances reuse the same server.sock path. The old Unix socket pathname is removed only when the next server reaches sock_create_server(), so it can remain visible during early startup.

The fixture treats path existence as readiness. If it observes that stale pathname, blkio-bench can connect before the new server is listening and fail with ECONNREFUSED.

Unlink the path before spawning the server.