### PR TITLE
qemu should notice the block device resize

### DIFF
--- a/blockdev.c
+++ b/blockdev.c
@@ -1,6 +1,5 @@
 #include <inttypes.h>
 #include <stdint.h>
-#include <string.h>
 
 #include "vhost/blockdev.h"
 #include "server_internal.h"
@@ -86,7 +85,7 @@ static void set_total_blocks_entry(struct vhd_work *work, void *opaque)
     vhd_complete_work(work, 0);
 }
 
-void vhd_blockdev_set_total_blocks(struct vhd_vdev *vdev, uint64_t total_blocks)
+static int set_total_blocks(struct vhd_vdev *vdev, uint64_t total_blocks)
 {
     struct set_total_blocks stb = {
         .vdev = vdev,
@@ -102,13 +101,23 @@ void vhd_blockdev_set_total_blocks(struct vhd_vdev *vdev, uint64_t total_blocks)
      * total_blocks in config is unrelated stopping process, so it should not be
      * a problem intersect with wdev_stop_work work.
      */
-    int ret = vhd_submit_ctl_work_and_wait(set_total_blocks_entry, &stb);
-    VHD_VERIFY(ret == 0);
+    return vhd_submit_ctl_work_and_wait(set_total_blocks_entry, &stb);
+}
 
-    ret = vhd_vdev_notify_config_change(vdev);
-    if (ret < 0) {
-        VHD_OBJ_WARN(vdev, "Failed to notify config change: %s", strerror(-ret));
+void vhd_blockdev_set_total_blocks(struct vhd_vdev *vdev, uint64_t total_blocks)
+{
+    int ret = set_total_blocks(vdev, total_blocks);
+    VHD_VERIFY(ret == 0);
+}
+
+int vhd_blockdev_resize(struct vhd_vdev *vdev, uint64_t total_blocks)
+{
+    int ret = set_total_blocks(vdev, total_blocks);
+    if (ret != 0) {
+        return ret;
     }
+
+    return vhd_vdev_notify_config_change(vdev);
 }
 
 static bool blockdev_validate_features(const struct vhd_bdev_info *bdev)

--- a/blockdev.c
+++ b/blockdev.c
@@ -1,5 +1,6 @@
 #include <inttypes.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "vhost/blockdev.h"
 #include "server_internal.h"
@@ -103,6 +104,11 @@ void vhd_blockdev_set_total_blocks(struct vhd_vdev *vdev, uint64_t total_blocks)
      */
     int ret = vhd_submit_ctl_work_and_wait(set_total_blocks_entry, &stb);
     VHD_VERIFY(ret == 0);
+
+    ret = vhd_vdev_notify_config_change(vdev);
+    if (ret < 0) {
+        VHD_OBJ_WARN(vdev, "Failed to notify config change: %s", strerror(-ret));
+    }
 }
 
 static bool blockdev_validate_features(const struct vhd_bdev_info *bdev)

--- a/include/vhost/blockdev.h
+++ b/include/vhost/blockdev.h
@@ -155,11 +155,9 @@ void vhd_unregister_blockdev(struct vhd_vdev *vdev,
 /**
  * Resize a vhost block device.
  *
- * The function change virtio config, that client may read by
- * VHOST_USER_GET_CONFIG command.
- *
- * Note, that client is not notified about config change, the caller is
- * responsible for this.
+ * The function changes virtio config, that client may read by
+ * VHOST_USER_GET_CONFIG command. If the client negotiated config-change
+ * notifications, it is notified after the config update.
  */
 void vhd_blockdev_set_total_blocks(struct vhd_vdev *vdev,
                                    uint64_t total_blocks);

--- a/include/vhost/blockdev.h
+++ b/include/vhost/blockdev.h
@@ -153,14 +153,29 @@ void vhd_unregister_blockdev(struct vhd_vdev *vdev,
                              void (*unregister_complete)(void *), void *arg);
 
 /**
- * Resize a vhost block device.
+ * Update a vhost block device size in its virtio config.
+ *
+ * The function changes virtio config, that client may read by
+ * VHOST_USER_GET_CONFIG command.
+ *
+ * Note, that client is not notified about config change, the caller is
+ * responsible for this.
+ */
+void vhd_blockdev_set_total_blocks(struct vhd_vdev *vdev,
+                                   uint64_t total_blocks);
+
+/**
+ * Resize a vhost block device and notify the client if possible.
  *
  * The function changes virtio config, that client may read by
  * VHOST_USER_GET_CONFIG command. If the client negotiated config-change
  * notifications, it is notified after the config update.
+ *
+ * Returns 0 on success, or a negative errno value when either the config update
+ * or the config-change notification fails.
  */
-void vhd_blockdev_set_total_blocks(struct vhd_vdev *vdev,
-                                   uint64_t total_blocks);
+int vhd_blockdev_resize(struct vhd_vdev *vdev,
+                        uint64_t total_blocks);
 
 #ifdef __cplusplus
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,6 +10,24 @@ if cc.get_id() == 'gcc'
     vhost_user_blk_test_server_args += ['-Wno-error=unused-result']
 endif
 
+vhost_config_change_test = executable(
+    'vhost-config-change-test',
+    'vhost_config_change_test.c',
+    link_with: libvhost,
+    dependencies: [libpthread],
+    include_directories: [
+        vhost_user_blk_test_server_includes,
+        libvhost_includes
+    ]
+)
+
+test(
+    'config-change-notification',
+    vhost_config_change_test,
+    timeout: 30,
+    is_parallel: false,
+)
+
 vhost_user_blk_test_server = executable(
     'vhost-user-blk-test-server',
     'vhost_user_blk_test_server.c',

--- a/tests/vhost_config_change_test.c
+++ b/tests/vhost_config_change_test.c
@@ -9,7 +9,23 @@
 
 #include "test_utils.h"
 #include "vdev.h"
+#include "vhost/blockdev.h"
 #include "vhost_spec.h"
+
+#define TEST_BLOCK_SIZE 4096
+#define TEST_INITIAL_BLOCKS 32
+#define TEST_RESIZED_BLOCKS 64
+#define TEST_PROTOCOL_FEATURES \
+    ((1UL << VHOST_USER_PROTOCOL_F_CONFIG) | \
+     (1UL << VHOST_USER_PROTOCOL_F_SLAVE_REQ))
+
+struct test_blockdev {
+    struct vhd_request_queue *rq;
+    struct vhd_vdev *vdev;
+    char socket_path[128];
+};
+
+static struct vhd_request_queue *g_test_rq;
 
 static int set_nonblock(int fd)
 {
@@ -25,7 +41,24 @@ static int set_nonblock(int fd)
     return 0;
 }
 
-static int read_config_change_msg(int fd)
+static int expect_no_data(int fd)
+{
+    char byte;
+
+    if (recv(fd, &byte, sizeof(byte), 0) >= 0) {
+        fprintf(stderr, "unexpected config-change message\n");
+        return -1;
+    }
+
+    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+        fprintf(stderr, "unexpected recv error: %s\n", strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
+static int read_config_change_msg(int fd, uint32_t expected_flags)
 {
     struct vhost_user_msg_hdr hdr;
     ssize_t ret = recv(fd, &hdr, sizeof(hdr), 0);
@@ -46,7 +79,7 @@ static int read_config_change_msg(int fd)
         return -1;
     }
 
-    if (hdr.flags != VHOST_USER_MSG_VERSION) {
+    if (hdr.flags != expected_flags) {
         fprintf(stderr, "unexpected flags 0x%x\n", hdr.flags);
         return -1;
     }
@@ -59,14 +92,86 @@ static int read_config_change_msg(int fd)
     return 0;
 }
 
+static void enable_notify_vdev(struct vhd_vdev *vdev, int slave_req_fd,
+                               uint64_t protocol_features)
+{
+    vdev->conn_handler = (struct vhd_io_handler *)1;
+    vdev->slave_req_fd = slave_req_fd;
+    vdev->negotiated_protocol_features = protocol_features;
+}
+
+static void disable_notify_vdev(struct vhd_vdev *vdev)
+{
+    vdev->conn_handler = NULL;
+    vdev->slave_req_fd = -1;
+    vdev->negotiated_protocol_features = 0;
+}
+
 static void init_notify_vdev(struct vhd_vdev *vdev, int slave_req_fd,
                              uint64_t protocol_features)
 {
     memset(vdev, 0, sizeof(*vdev));
     vdev->log_tag = "config-change-test";
-    vdev->conn_handler = (struct vhd_io_handler *)1;
-    vdev->slave_req_fd = slave_req_fd;
-    vdev->negotiated_protocol_features = protocol_features;
+    enable_notify_vdev(vdev, slave_req_fd, protocol_features);
+}
+
+static int init_test_blockdev(struct test_blockdev *dev)
+{
+    struct vhd_request_queue *rqs[1];
+    struct vhd_bdev_info info = {
+        .serial = "config-change-test",
+        .block_size = TEST_BLOCK_SIZE,
+        .optimal_io_size = TEST_BLOCK_SIZE,
+        .num_queues = 1,
+        .total_blocks = TEST_INITIAL_BLOCKS,
+    };
+
+    memset(dev, 0, sizeof(*dev));
+    snprintf(dev->socket_path, sizeof(dev->socket_path),
+             "/tmp/vhost-config-change-test-%ld.sock", (long)getpid());
+    unlink(dev->socket_path);
+    info.socket_path = dev->socket_path;
+
+    if (!g_test_rq) {
+        g_test_rq = vhd_create_request_queue();
+        if (!g_test_rq) {
+            fprintf(stderr, "vhd_create_request_queue failed\n");
+            return -1;
+        }
+    }
+
+    dev->rq = g_test_rq;
+    rqs[0] = dev->rq;
+    dev->vdev = vhd_register_blockdev(&info, rqs, 1, NULL);
+    if (!dev->vdev) {
+        fprintf(stderr, "vhd_register_blockdev failed\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+static void cleanup_test_blockdev(struct test_blockdev *dev)
+{
+    if (dev->vdev) {
+        disable_notify_vdev(dev->vdev);
+        vhd_unregister_blockdev(dev->vdev, NULL, NULL);
+    }
+    if (dev->socket_path[0]) {
+        unlink(dev->socket_path);
+    }
+}
+
+static void cleanup_test_request_queue(void)
+{
+    if (!g_test_rq) {
+        return;
+    }
+
+    vhd_stop_queue(g_test_rq);
+    vhd_run_queue(g_test_rq);
+    vhd_release_request_queue(g_test_rq);
+    g_test_rq = NULL;
 }
 
 static int test_notify_config_change(void)
@@ -86,15 +191,14 @@ static int test_notify_config_change(void)
     }
 
     init_notify_vdev(&vdev, sockets[0],
-        (1UL << VHOST_USER_PROTOCOL_F_CONFIG) |
-        (1UL << VHOST_USER_PROTOCOL_F_SLAVE_REQ));
+        TEST_PROTOCOL_FEATURES);
 
     if (vhd_vdev_notify_config_change(&vdev) != 0) {
         fprintf(stderr, "vhd_vdev_notify_config_change failed\n");
         goto out;
     }
 
-    ret = read_config_change_msg(sockets[1]);
+    ret = read_config_change_msg(sockets[1], VHOST_USER_MSG_VERSION);
 
 out:
     close(sockets[0]);
@@ -107,7 +211,6 @@ static int test_notify_skips_without_negotiated_features(void)
     struct vhd_vdev vdev;
     int sockets[2] = {-1, -1};
     int ret = -1;
-    char byte;
 
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0) {
         fprintf(stderr, "socketpair failed: %s\n", strerror(errno));
@@ -126,13 +229,7 @@ static int test_notify_skips_without_negotiated_features(void)
         goto out;
     }
 
-    if (recv(sockets[1], &byte, sizeof(byte), 0) >= 0) {
-        fprintf(stderr, "unexpected config-change message\n");
-        goto out;
-    }
-
-    if (errno != EAGAIN && errno != EWOULDBLOCK) {
-        fprintf(stderr, "unexpected recv error: %s\n", strerror(errno));
+    if (expect_no_data(sockets[1]) != 0) {
         goto out;
     }
 
@@ -141,6 +238,141 @@ static int test_notify_skips_without_negotiated_features(void)
 out:
     close(sockets[0]);
     close(sockets[1]);
+    return ret;
+}
+
+static int test_notify_config_change_returns_send_error(void)
+{
+    struct vhd_vdev vdev;
+    int sockets[2] = {-1, -1};
+    int ret = -1;
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0) {
+        fprintf(stderr, "socketpair failed: %s\n", strerror(errno));
+        return -1;
+    }
+
+    init_notify_vdev(&vdev, sockets[0],
+        TEST_PROTOCOL_FEATURES);
+
+    close(sockets[1]);
+    sockets[1] = -1;
+
+    if (vhd_vdev_notify_config_change(&vdev) == 0) {
+        fprintf(stderr, "vhd_vdev_notify_config_change unexpectedly succeeded\n");
+        goto out;
+    }
+
+    ret = 0;
+
+out:
+    close(sockets[0]);
+    return ret;
+}
+
+static int test_blockdev_set_total_blocks_does_not_notify(void)
+{
+    struct test_blockdev dev;
+    int sockets[2] = {-1, -1};
+    int ret = -1;
+
+    if (init_test_blockdev(&dev) != 0) {
+        return -1;
+    }
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0) {
+        fprintf(stderr, "socketpair failed: %s\n", strerror(errno));
+        goto out;
+    }
+
+    if (set_nonblock(sockets[1]) < 0) {
+        fprintf(stderr, "failed to set nonblocking mode: %s\n", strerror(errno));
+        goto out;
+    }
+
+    enable_notify_vdev(dev.vdev, sockets[0], TEST_PROTOCOL_FEATURES);
+
+    vhd_blockdev_set_total_blocks(dev.vdev, TEST_RESIZED_BLOCKS);
+    ret = expect_no_data(sockets[1]);
+
+out:
+    if (sockets[0] >= 0) {
+        close(sockets[0]);
+    }
+    if (sockets[1] >= 0) {
+        close(sockets[1]);
+    }
+    cleanup_test_blockdev(&dev);
+    return ret;
+}
+
+static int test_blockdev_resize_notifies_config_change(void)
+{
+    struct test_blockdev dev;
+    int sockets[2] = {-1, -1};
+    int ret = -1;
+
+    if (init_test_blockdev(&dev) != 0) {
+        return -1;
+    }
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0) {
+        fprintf(stderr, "socketpair failed: %s\n", strerror(errno));
+        goto out;
+    }
+
+    enable_notify_vdev(dev.vdev, sockets[0], TEST_PROTOCOL_FEATURES);
+
+    if (vhd_blockdev_resize(dev.vdev, TEST_RESIZED_BLOCKS) != 0) {
+        fprintf(stderr, "vhd_blockdev_resize failed\n");
+        goto out;
+    }
+
+    ret = read_config_change_msg(sockets[1], VHOST_USER_MSG_VERSION);
+
+out:
+    if (sockets[0] >= 0) {
+        close(sockets[0]);
+    }
+    if (sockets[1] >= 0) {
+        close(sockets[1]);
+    }
+    cleanup_test_blockdev(&dev);
+    return ret;
+}
+
+static int test_blockdev_resize_returns_send_error(void)
+{
+    struct test_blockdev dev;
+    int sockets[2] = {-1, -1};
+    int ret = -1;
+
+    if (init_test_blockdev(&dev) != 0) {
+        return -1;
+    }
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0) {
+        fprintf(stderr, "socketpair failed: %s\n", strerror(errno));
+        goto out;
+    }
+
+    enable_notify_vdev(dev.vdev, sockets[0], TEST_PROTOCOL_FEATURES);
+
+    close(sockets[1]);
+    sockets[1] = -1;
+
+    if (vhd_blockdev_resize(dev.vdev, TEST_RESIZED_BLOCKS) == 0) {
+        fprintf(stderr, "vhd_blockdev_resize unexpectedly succeeded\n");
+        goto out;
+    }
+
+    ret = 0;
+
+out:
+    if (sockets[0] >= 0) {
+        close(sockets[0]);
+    }
+    cleanup_test_blockdev(&dev);
     return ret;
 }
 
@@ -157,13 +389,30 @@ int main(void)
         goto out;
     }
 
+    if (test_notify_config_change_returns_send_error() != 0) {
+        goto out;
+    }
+
     if (test_notify_skips_without_negotiated_features() != 0) {
+        goto out;
+    }
+
+    if (test_blockdev_set_total_blocks_does_not_notify() != 0) {
+        goto out;
+    }
+
+    if (test_blockdev_resize_notifies_config_change() != 0) {
+        goto out;
+    }
+
+    if (test_blockdev_resize_returns_send_error() != 0) {
         goto out;
     }
 
     ret = 0;
 
 out:
+    cleanup_test_request_queue();
     vhd_stop_vhost_server();
     return ret;
 }

--- a/tests/vhost_config_change_test.c
+++ b/tests/vhost_config_change_test.c
@@ -1,0 +1,169 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "test_utils.h"
+#include "vdev.h"
+#include "vhost_spec.h"
+
+static int set_nonblock(int fd)
+{
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) {
+        return -errno;
+    }
+
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+        return -errno;
+    }
+
+    return 0;
+}
+
+static int read_config_change_msg(int fd)
+{
+    struct vhost_user_msg_hdr hdr;
+    ssize_t ret = recv(fd, &hdr, sizeof(hdr), 0);
+
+    if (ret < 0) {
+        fprintf(stderr, "recv failed: %s\n", strerror(errno));
+        return -1;
+    }
+
+    if ((size_t)ret != sizeof(hdr)) {
+        fprintf(stderr, "recv returned %zd bytes, expected %zu\n",
+                ret, sizeof(hdr));
+        return -1;
+    }
+
+    if (hdr.req != VHOST_USER_SLAVE_CONFIG_CHANGE_MSG) {
+        fprintf(stderr, "unexpected request %u\n", hdr.req);
+        return -1;
+    }
+
+    if (hdr.flags != VHOST_USER_MSG_VERSION) {
+        fprintf(stderr, "unexpected flags 0x%x\n", hdr.flags);
+        return -1;
+    }
+
+    if (hdr.size != 0) {
+        fprintf(stderr, "unexpected payload size %u\n", hdr.size);
+        return -1;
+    }
+
+    return 0;
+}
+
+static void init_notify_vdev(struct vhd_vdev *vdev, int slave_req_fd,
+                             uint64_t protocol_features)
+{
+    memset(vdev, 0, sizeof(*vdev));
+    vdev->log_tag = "config-change-test";
+    vdev->conn_handler = (struct vhd_io_handler *)1;
+    vdev->slave_req_fd = slave_req_fd;
+    vdev->negotiated_protocol_features = protocol_features;
+}
+
+static int test_notify_config_change(void)
+{
+    struct vhd_vdev vdev;
+    int sockets[2] = {-1, -1};
+    int ret = -1;
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0) {
+        fprintf(stderr, "socketpair failed: %s\n", strerror(errno));
+        return -1;
+    }
+
+    if (set_nonblock(sockets[1]) < 0) {
+        fprintf(stderr, "failed to set nonblocking mode: %s\n", strerror(errno));
+        goto out;
+    }
+
+    init_notify_vdev(&vdev, sockets[0],
+        (1UL << VHOST_USER_PROTOCOL_F_CONFIG) |
+        (1UL << VHOST_USER_PROTOCOL_F_SLAVE_REQ));
+
+    if (vhd_vdev_notify_config_change(&vdev) != 0) {
+        fprintf(stderr, "vhd_vdev_notify_config_change failed\n");
+        goto out;
+    }
+
+    ret = read_config_change_msg(sockets[1]);
+
+out:
+    close(sockets[0]);
+    close(sockets[1]);
+    return ret;
+}
+
+static int test_notify_skips_without_negotiated_features(void)
+{
+    struct vhd_vdev vdev;
+    int sockets[2] = {-1, -1};
+    int ret = -1;
+    char byte;
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0) {
+        fprintf(stderr, "socketpair failed: %s\n", strerror(errno));
+        return -1;
+    }
+
+    if (set_nonblock(sockets[1]) < 0) {
+        fprintf(stderr, "failed to set nonblocking mode: %s\n", strerror(errno));
+        goto out;
+    }
+
+    init_notify_vdev(&vdev, sockets[0], 0);
+
+    if (vhd_vdev_notify_config_change(&vdev) != 0) {
+        fprintf(stderr, "vhd_vdev_notify_config_change failed\n");
+        goto out;
+    }
+
+    if (recv(sockets[1], &byte, sizeof(byte), 0) >= 0) {
+        fprintf(stderr, "unexpected config-change message\n");
+        goto out;
+    }
+
+    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+        fprintf(stderr, "unexpected recv error: %s\n", strerror(errno));
+        goto out;
+    }
+
+    ret = 0;
+
+out:
+    close(sockets[0]);
+    close(sockets[1]);
+    return ret;
+}
+
+int main(void)
+{
+    int ret = 1;
+
+    if (vhd_start_vhost_server(vhd_log_stderr) != 0) {
+        fprintf(stderr, "failed to start vhost server\n");
+        return 1;
+    }
+
+    if (test_notify_config_change() != 0) {
+        goto out;
+    }
+
+    if (test_notify_skips_without_negotiated_features() != 0) {
+        goto out;
+    }
+
+    ret = 0;
+
+out:
+    vhd_stop_vhost_server();
+    return ret;
+}

--- a/tests/vhost_user_blk_test_server.c
+++ b/tests/vhost_user_blk_test_server.c
@@ -867,7 +867,10 @@ static int resize(struct disk *d, uint64_t new_size)
         return ret;
     }
 
-    vhd_blockdev_set_total_blocks(d->handler, new_size / block_size);
+    ret = vhd_blockdev_resize(d->handler, new_size / block_size);
+    if (ret < 0) {
+        return ret;
+    }
 
     vhd_log_stderr(LOG_INFO, "Resized succesfully to %" PRIu64, new_size);
 

--- a/vdev.c
+++ b/vdev.c
@@ -606,6 +606,7 @@ static const uint64_t g_default_protocol_features =
     (1UL << VHOST_USER_PROTOCOL_F_MQ) |
     (1UL << VHOST_USER_PROTOCOL_F_LOG_SHMFD) |
     (1UL << VHOST_USER_PROTOCOL_F_REPLY_ACK) |
+    (1UL << VHOST_USER_PROTOCOL_F_SLAVE_REQ) |
     (1UL << VHOST_USER_PROTOCOL_F_CONFIG) |
     (1UL << VHOST_USER_PROTOCOL_F_INFLIGHT_SHMFD) |
     (1UL << VHOST_USER_PROTOCOL_F_CONFIGURE_MEM_SLOTS) |
@@ -796,6 +797,37 @@ static int vhost_set_protocol_features(struct vhd_vdev *vdev,
     }
 
     vdev->negotiated_protocol_features = *features;
+
+    return vhost_ack(vdev, 0);
+}
+
+static int vhost_set_slave_req_fd(struct vhd_vdev *vdev,
+                                  const void *payload, size_t size,
+                                  const int *fds, size_t num_fds)
+{
+    int fd;
+
+    if (size || num_fds != 1) {
+        VHD_OBJ_ERROR(vdev, "malformed message size=%zu #fds=%zu", size,
+                      num_fds);
+        return -EINVAL;
+    }
+
+    if (!has_feature(vdev->negotiated_protocol_features,
+                     VHOST_USER_PROTOCOL_F_SLAVE_REQ)) {
+        VHD_OBJ_ERROR(vdev, "SET_SLAVE_REQ_FD without negotiated feature");
+        return -EINVAL;
+    }
+
+    fd = fcntl(fds[0], F_DUPFD_CLOEXEC, 0);
+    if (fd < 0) {
+        int ret = -errno;
+        VHD_OBJ_ERROR(vdev, "failed to duplicate slave request fd: %s",
+                      strerror(-ret));
+        return ret;
+    }
+
+    replace_fd(&vdev->slave_req_fd, fd);
 
     return vhost_ack(vdev, 0);
 }
@@ -1936,6 +1968,7 @@ static int (*vhost_msg_handlers[])(struct vhd_vdev *vdev,
     [VHOST_USER_SET_OWNER]              = vhost_set_owner,
     [VHOST_USER_GET_PROTOCOL_FEATURES]  = vhost_get_protocol_features,
     [VHOST_USER_SET_PROTOCOL_FEATURES]  = vhost_set_protocol_features,
+    [VHOST_USER_SET_SLAVE_REQ_FD]       = vhost_set_slave_req_fd,
     [VHOST_USER_GET_CONFIG]             = vhost_get_config,
     [VHOST_USER_SET_MEM_TABLE]          = vhost_set_mem_table,
     [VHOST_USER_GET_QUEUE_NUM]          = vhost_get_queue_num,
@@ -2071,12 +2104,47 @@ static void vdev_cleanup(struct vhd_vdev *vdev)
         replace_fd(&vdev->timerfd, -1);
     }
 
+    replace_fd(&vdev->slave_req_fd, -1);
+
     /*
      * Closing the connection should go last, so that the client doesn't see
      * the need to reconnect until the server detaches from the client's
      * mappings.
      */
      replace_fd(&vdev->connfd, -1);
+}
+
+static void notify_config_change_entry(struct vhd_work *work, void *opaque)
+{
+    struct vhd_vdev *vdev = opaque;
+    struct vhost_user_msg_hdr hdr = {
+        .req = VHOST_USER_SLAVE_CONFIG_CHANGE_MSG,
+        .flags = VHOST_USER_MSG_VERSION,
+    };
+    int ret = 0;
+
+    if (!vdev->conn_handler ||
+        vdev->slave_req_fd < 0 ||
+        !has_feature(vdev->negotiated_protocol_features,
+                     VHOST_USER_PROTOCOL_F_CONFIG) ||
+        !has_feature(vdev->negotiated_protocol_features,
+                     VHOST_USER_PROTOCOL_F_SLAVE_REQ)) {
+        goto out;
+    }
+
+    VHD_OBJ_INFO(vdev, "Notify config change");
+    ret = net_send_msg(vdev->slave_req_fd, &hdr, NULL, NULL, 0);
+    if (ret > 0) {
+        ret = 0;
+    }
+
+out:
+    vhd_complete_work(work, ret);
+}
+
+int vhd_vdev_notify_config_change(struct vhd_vdev *vdev)
+{
+    return vhd_submit_ctl_work_and_wait(notify_config_change_entry, vdev);
 }
 
 static void vhd_vdev_release(struct vhd_vdev *vdev)
@@ -2408,6 +2476,7 @@ int vhd_vdev_init_server(
         .type = type,
         .listenfd = listenfd,
         .connfd = -1,
+        .slave_req_fd = -1,
         .req = VHOST_USER_NONE,
         .rqs = vhd_rqs,
         .num_rqs = num_rqs,

--- a/vdev.h
+++ b/vdev.h
@@ -57,6 +57,9 @@ struct vhd_vdev {
     int connfd;
     struct vhd_io_handler *conn_handler;
 
+    /* Backend-to-frontend request fd, negotiated via SET_SLAVE_REQ_FD. */
+    int slave_req_fd;
+
     /* Message currently being handled */
     uint32_t req;
 
@@ -163,6 +166,14 @@ int vhd_vdev_init_server(
  */
 int vhd_vdev_stop_server(struct vhd_vdev *vdev,
                          void (*release_cb)(void *), void *release_arg);
+
+/**
+ * Notify the connected client that device configuration has changed.
+ *
+ * Returns 0 when the notification was sent or when there is no connected
+ * client with negotiated config-change notifications.
+ */
+int vhd_vdev_notify_config_change(struct vhd_vdev *vdev);
 
 /**
  * Device vring instance

--- a/vhost_spec.h
+++ b/vhost_spec.h
@@ -108,6 +108,9 @@ enum {
     VHOST_USER_REM_MEM_REG = 38,
 };
 
+/* Slave request types. */
+#define VHOST_USER_SLAVE_CONFIG_CHANGE_MSG 2
+
 struct vhost_user_mem_region {
     uint64_t guest_addr;
     uint64_t size;


### PR DESCRIPTION
Needed for https://github.com/ydb-platform/nbs/pull/6671
Can also use `NEED_REPLY`, but still wasn't able to make the resize pipeline fully synchronous, so maybe it's fine even without that.
